### PR TITLE
Don't package base library

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,5 +4,6 @@
     <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <BigQueryPackageVersion>3.0.0</BigQueryPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Dfe.Analytics.AspNetCore/Dfe.Analytics.AspNetCore.csproj
+++ b/src/Dfe.Analytics.AspNetCore/Dfe.Analytics.AspNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -16,16 +16,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Dfe.Analytics\Event.cs" Link="Event.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="$(BigQueryPackageVersion)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Dfe.Analytics\Dfe.Analytics.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Dfe.Analytics/Dfe.Analytics.csproj
+++ b/src/Dfe.Analytics/Dfe.Analytics.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="3.1.0" />
+    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="$(BigQueryPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The solution is split into a core project and an ASP.NET Core project. This is looking forward to when EF Core support comes in and we will have a common 'core' library with on-demand integration with ASP.NET Core and EF Core.

The down-side of this split is the need to publish multiple packages and the associated versioning challenges (see
https://stackoverflow.com/questions/53278544/nuget-versioning-with-projectreference-dependencies).

For now include the core type as source into the AspNetCore project so we can publish a single package.