### PR TITLE
Make BigQueryClient construction pluggable

### DIFF
--- a/src/Dfe.Analytics/AspNetCore/DfeAnalyticsMiddleware.cs
+++ b/src/Dfe.Analytics/AspNetCore/DfeAnalyticsMiddleware.cs
@@ -11,27 +11,32 @@ namespace Dfe.Analytics.AspNetCore;
 public class DfeAnalyticsMiddleware
 {
     private readonly RequestDelegate _next;
+    private readonly IBigQueryClientProvider _bigQueryClientProvider;
     private readonly ILogger<DfeAnalyticsMiddleware> _logger;
 
     /// <summary>
     /// Creates a new <see cref="DfeAnalyticsMiddleware"/>.
     /// </summary>
     /// <param name="next">The <see cref="RequestDelegate"/> representing the next middleware in the pipeline.</param>
+    /// <param name="bigQueryClientProvider">The <see cref="IBigQueryClientProvider"/>.</param>
     /// <param name="optionsAccessor">The configuration options.</param>
     /// <param name="aspNetCoreOptionsAccessor">The middleware configuration options.</param>
     /// <param name="logger">The logger instance.</param>
     public DfeAnalyticsMiddleware(
         RequestDelegate next,
+        IBigQueryClientProvider bigQueryClientProvider,
         IOptions<DfeAnalyticsOptions> optionsAccessor,
         IOptions<DfeAnalyticsAspNetCoreOptions> aspNetCoreOptionsAccessor,
         ILogger<DfeAnalyticsMiddleware> logger)
     {
         ArgumentNullException.ThrowIfNull(next);
+        ArgumentNullException.ThrowIfNull(bigQueryClientProvider);
         ArgumentNullException.ThrowIfNull(optionsAccessor);
         ArgumentNullException.ThrowIfNull(aspNetCoreOptionsAccessor);
         ArgumentNullException.ThrowIfNull(logger);
 
         _next = next;
+        _bigQueryClientProvider = bigQueryClientProvider;
         Options = optionsAccessor.Value;
         AspNetCoreOptions = aspNetCoreOptionsAccessor.Value;
         _logger = logger;
@@ -78,7 +83,9 @@ public class DfeAnalyticsMiddleware
 
             try
             {
-                await Options.BigQueryClient.InsertRowAsync(
+                var bigQueryClient = await _bigQueryClientProvider.GetBigQueryClientAsync();
+
+                await bigQueryClient.InsertRowAsync(
                     Options.DatasetId,
                     Options.TableId,
                     row);

--- a/src/Dfe.Analytics/DfeAnalyticsConfigureOptions.cs
+++ b/src/Dfe.Analytics/DfeAnalyticsConfigureOptions.cs
@@ -30,14 +30,13 @@ internal class DfeAnalyticsConfigureOptions : IConfigureOptions<DfeAnalyticsOpti
 
         if (!string.IsNullOrEmpty(credentialsJson))
         {
+            var credentialsJsonDoc = JsonDocument.Parse(credentialsJson);
+
             var projectId = section["ProjectId"];
 
             if (projectId is null)
             {
                 // We don't have ProjectId configured explicitly; see if it's set in the JSON credentials
-
-                var credentialsJsonDoc = JsonDocument.Parse(credentialsJson);
-
                 if (credentialsJsonDoc.RootElement.TryGetProperty("project_id", out var projectIdElement) &&
                     projectIdElement.ValueKind == JsonValueKind.String)
                 {
@@ -45,7 +44,7 @@ internal class DfeAnalyticsConfigureOptions : IConfigureOptions<DfeAnalyticsOpti
                 }
             }
 
-            if (projectId is not null)
+            if (credentialsJsonDoc.RootElement.TryGetProperty("private_key", out _) && projectId is not null)
             {
                 var creds = GoogleCredential.FromJson(credentialsJson);
                 options.BigQueryClient = BigQueryClient.Create(projectId, creds);

--- a/src/Dfe.Analytics/DfeAnalyticsOptions.cs
+++ b/src/Dfe.Analytics/DfeAnalyticsOptions.cs
@@ -11,7 +11,6 @@ public class DfeAnalyticsOptions
     /// <summary>
     /// The <see cref="BigQueryClient"/> to send events with.
     /// </summary>
-    [DisallowNull]
     public BigQueryClient? BigQueryClient { get; set; }
 
     /// <summary>
@@ -43,17 +42,11 @@ public class DfeAnalyticsOptions
     /// </remarks>
     public string? Namespace { get; set; }
 
-    [MemberNotNull(nameof(BigQueryClient))]
     [MemberNotNull(nameof(DatasetId))]
     [MemberNotNull(nameof(TableId))]
     [MemberNotNull(nameof(Environment))]
     internal void ValidateOptions()
     {
-        if (BigQueryClient is null)
-        {
-            throw new InvalidOperationException($"{nameof(BigQueryClient)} has not been configured.");
-        }
-
         if (DatasetId is null)
         {
             throw new InvalidOperationException($"{nameof(DatasetId)} has not been configured.");

--- a/src/Dfe.Analytics/Extensions.cs
+++ b/src/Dfe.Analytics/Extensions.cs
@@ -37,6 +37,7 @@ public static class Extensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<DfeAnalyticsOptions>, DfeAnalyticsConfigureOptions>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<DfeAnalyticsOptions>, DfeAnalyticsPostConfigureOptions>());
         services.Configure(setupAction);
+        services.TryAddSingleton<IBigQueryClientProvider, OptionsBigQueryClientProvider>();
 
         return new DfeAnalyticsBuilder(services);
     }

--- a/src/Dfe.Analytics/IBigQueryClientProvider.cs
+++ b/src/Dfe.Analytics/IBigQueryClientProvider.cs
@@ -1,0 +1,15 @@
+using Google.Cloud.BigQuery.V2;
+
+namespace Dfe.Analytics;
+
+/// <summary>
+/// Represents a type that can return an authenticated <see cref="BigQueryClient"/>.
+/// </summary>
+public interface IBigQueryClientProvider
+{
+    /// <summary>
+    /// Gets a <see cref="BigQueryClient"/>.
+    /// </summary>
+    /// <returns>An authenticated <see cref="BigQueryClient"/>.</returns>
+    ValueTask<BigQueryClient> GetBigQueryClientAsync();
+}

--- a/src/Dfe.Analytics/OptionsBigQueryClientProvider.cs
+++ b/src/Dfe.Analytics/OptionsBigQueryClientProvider.cs
@@ -1,0 +1,31 @@
+using Google.Cloud.BigQuery.V2;
+using Microsoft.Extensions.Options;
+
+namespace Dfe.Analytics;
+
+/// <summary>
+/// An implementation of <see cref="IBigQueryClientProvider"/> that retrieves a <see cref="BigQueryClient"/> from <see cref="DfeAnalyticsOptions"/>.
+/// </summary>
+public class OptionsBigQueryClientProvider : IBigQueryClientProvider
+{
+    private readonly IOptions<DfeAnalyticsOptions> _optionsAccessor;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="OptionsBigQueryClientProvider"/>.
+    /// </summary>
+    /// <param name="optionsAccessor">The <see cref="DfeAnalyticsOptions"/>.</param>
+    public OptionsBigQueryClientProvider(IOptions<DfeAnalyticsOptions> optionsAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(optionsAccessor);
+        _optionsAccessor = optionsAccessor;
+    }
+
+    /// <inheritdoc/>
+    public ValueTask<BigQueryClient> GetBigQueryClientAsync()
+    {
+        var configuredClient = _optionsAccessor.Value.BigQueryClient ??
+            throw new InvalidOperationException($"No {nameof(DfeAnalyticsOptions.BigQueryClient)} has been configured.");
+
+        return new ValueTask<BigQueryClient>(configuredClient);
+    }
+}


### PR DESCRIPTION
For federated authentication with AKS we need an extensibility point to configure how a `BigQueryClient` is constructed and retrieved. This adds that.

This also prevents trying to create a `BigQueryClient` from the JSON configuration unless there's a `private_key` property present.