### PR TITLE
Revert the NuGet publishing step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,20 +39,3 @@ jobs:
           src/Dfe.Analytics/bin/Release/*.nupkg
           src/Dfe.Analytics/bin/Release/*.snupkg
         if-no-files-found: error
-
-  release:
-    name: "Release"
-    runs-on: ubuntu-latest
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-
-    steps:
-    - name: Download package artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: Dfe.Analytics.nupkg
-
-    - name: Publish package to NuGet
-      run: dotnet nuget push **/*.nupkg --api-key $NUGET_TOKEN --source https://api.nuget.org/v3/index.json --skip-duplicate
-      env:
-          NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}


### PR DESCRIPTION
The package (or prefix) is reserved so the package publishing fails.