### PR TITLE
Add options to use the original status code and request URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+Adds `RestoreOriginalPathAndQueryString` and `RestoreOriginalStatusCode` properties to `DfeAnalyticsAspNetCoreOptions`.
+
 ## 0.2.1
 
 A `IWebRequestEventEnricher` interface has been added so that applications can modify web request events before they are sent to BigQuery.

--- a/src/Dfe.Analytics/AspNetCore/DfeAnalyticsAspNetCoreConfigureOptions.cs
+++ b/src/Dfe.Analytics/AspNetCore/DfeAnalyticsAspNetCoreConfigureOptions.cs
@@ -20,5 +20,7 @@ internal class DfeAnalyticsAspNetCoreConfigureOptions : IConfigureOptions<DfeAna
 
         section.AssignConfigurationValueIfNotEmpty("UserIdClaimType", v => options.UserIdClaimType = v);
         section.AssignConfigurationValueIfNotEmpty("PseudonymizeUserId", v => options.PseudonymizeUserId = bool.Parse(v));
+        section.AssignConfigurationValueIfNotEmpty("RestoreOriginalPathAndQueryString", v => options.RestoreOriginalPathAndQueryString = bool.Parse(v));
+        section.AssignConfigurationValueIfNotEmpty("RestoreOriginalStatusCode", v => options.RestoreOriginalStatusCode = bool.Parse(v));
     }
 }

--- a/src/Dfe.Analytics/AspNetCore/DfeAnalyticsAspNetCoreOptions.cs
+++ b/src/Dfe.Analytics/AspNetCore/DfeAnalyticsAspNetCoreOptions.cs
@@ -41,6 +41,21 @@ public class DfeAnalyticsAspNetCoreOptions
     public PartitionedRateLimiter<HttpContext>? RateLimiter { get; set; }
 
     /// <summary>
+    /// Whether the original path and query string should be used for requests that have been reexecuted
+    /// using StatusCodePagesMiddleware or ExceptionHandlerMiddleware.
+    /// </summary>
+    /// <remarks>
+    /// The default is <see langword="true"/>.
+    /// </remarks>
+    public bool RestoreOriginalPathAndQueryString { get; set; } = true;
+
+    /// <summary>
+    /// Whether the original response status code should be used for requests that have been reexecuted
+    /// using StatusCodePagesMiddleware.
+    /// </summary>
+    public bool RestoreOriginalStatusCode { get; set; } = false;
+
+    /// <summary>
     /// Gets the current user's ID from the <see cref="HttpContext"/> using the <see cref="UserIdClaimType"/> claim.
     /// </summary>
     /// <param name="httpContext">The <see cref="HttpContext"/>.</param>


### PR DESCRIPTION
When `IStatusCodeReExecuteFeature` or `IExceptionHandlerFeature` are used (i.e. `app.UseStatusCodePagesWithReExecute()` and `app.UseExceptionHandler()`) the response status code and request URL that the middleware sees don't necessarily match what should be logged. This adds two new options - `RestoreOriginalPathAndQueryString` (defaults to `true`) and `RestoreOriginalStatusCode` (defaults to `false`) - to allow recording the original values.