### PR TITLE
Amend federated auth config to work with JSON credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0  # Important for minver to create the right version number
 
     - name: Restore
       run: dotnet restore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+Amended `FederatedAksAuthenticationOptions` to reduce the number of options required; `Audience` and `GenerateAccessTokenUrl` are now the only keys required.
+For backwards compatibility these will be derived from the old configuration keys if they're provided.
+
+If `CredentialsJson` is available in configuration then `Audience` and `GenerateAccessTokenUrl` will be sourced from there.
+
 ## 0.2.3
 
 Fixed `ProjectNumber` option to read from `ProjectNumber` configuration key instead of `ProjectId`.

--- a/src/Dfe.Analytics/DfeAnalyticsConfigureOptions.cs
+++ b/src/Dfe.Analytics/DfeAnalyticsConfigureOptions.cs
@@ -31,19 +31,17 @@ internal class DfeAnalyticsConfigureOptions : IConfigureOptions<DfeAnalyticsOpti
 
         if (!string.IsNullOrEmpty(credentialsJson))
         {
-            var credentialsJsonDoc = JsonDocument.Parse(credentialsJson);
-
-            var projectId = options.ProjectId;
+            using var credentialsJsonDoc = JsonDocument.Parse(credentialsJson);
 
             // We don't have ProjectId configured explicitly; see if it's set in the JSON credentials
-            if (projectId is null &&
+            if (options.ProjectId is null &&
                 credentialsJsonDoc.RootElement.TryGetProperty("project_id", out var projectIdElement) &&
                 projectIdElement.ValueKind == JsonValueKind.String)
             {
-                projectId = projectIdElement.GetString();
+                options.ProjectId = projectIdElement.GetString();
             }
 
-            if (credentialsJsonDoc.RootElement.TryGetProperty("private_key", out _) && projectId is not null)
+            if (credentialsJsonDoc.RootElement.TryGetProperty("private_key", out _) && options.ProjectId is string projectId)
             {
                 var creds = GoogleCredential.FromJson(credentialsJson);
                 options.BigQueryClient = BigQueryClient.Create(projectId, creds);

--- a/src/Dfe.Analytics/FederatedAksAuthenticationConfigureOptions.cs
+++ b/src/Dfe.Analytics/FederatedAksAuthenticationConfigureOptions.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -18,9 +19,44 @@ internal class FederatedAksAuthenticationConfigureOptions : IConfigureOptions<Fe
 
         var section = _configuration.GetSection(Constants.RootConfigurationSectionName);
 
-        section.AssignConfigurationValueIfNotEmpty("ProjectNumber", v => options.ProjectNumber = v);
-        section.AssignConfigurationValueIfNotEmpty("WorkloadIdentityPoolName", v => options.WorkloadIdentityPoolName = v);
-        section.AssignConfigurationValueIfNotEmpty("WorkloadIdentityPoolProviderName", v => options.WorkloadIdentityPoolProviderName = v);
-        section.AssignConfigurationValueIfNotEmpty("ServiceAccountEmail", v => options.ServiceAccountEmail = v);
+        section.AssignConfigurationValueIfNotEmpty("Audience", v => options.Audience = v);
+        section.AssignConfigurationValueIfNotEmpty("GenerateAccessTokenUrl", v => options.GenerateAccessTokenUrl = v);
+
+        if (options.Audience is null &&
+            section["ProjectNumber"] is string projectNumber &&
+            section["WorkloadIdentityPoolName"] is string workloadIdentityPoolName &&
+            section["WorkloadIdentityPoolProviderName"] is string workloadIdentityPoolProviderName)
+        {
+            options.Audience = $"//iam.googleapis.com/projects/{Uri.EscapeDataString(projectNumber)}/" +
+                $"locations/global/workloadIdentityPools/{Uri.EscapeDataString(workloadIdentityPoolName)}/" +
+                $"providers/{Uri.EscapeDataString(workloadIdentityPoolProviderName)}";
+        }
+
+        if (options.GenerateAccessTokenUrl is null &&
+            section["ServiceAccountEmail"] is string serviceAccountEmail)
+        {
+            options.GenerateAccessTokenUrl = $"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{Uri.EscapeDataString(serviceAccountEmail)}:generateAccessToken";
+        }
+
+        var credentialsJson = section["CredentialsJson"];
+
+        if (!string.IsNullOrEmpty(credentialsJson))
+        {
+            using var credentialsJsonDoc = JsonDocument.Parse(credentialsJson);
+
+            if (options.Audience is null &&
+                credentialsJsonDoc.RootElement.TryGetProperty("audience", out var audienceElement) &&
+                audienceElement.ValueKind == JsonValueKind.String)
+            {
+                options.Audience = audienceElement.GetString()!;
+            }
+
+            if (options.GenerateAccessTokenUrl is null &&
+                credentialsJsonDoc.RootElement.TryGetProperty("service_account_impersonation_url", out var impersonationUrlElement) &&
+                impersonationUrlElement.ValueKind != JsonValueKind.String)
+            {
+                options.GenerateAccessTokenUrl = impersonationUrlElement.GetString()!;
+            }
+        }
     }
 }

--- a/src/Dfe.Analytics/FederatedAksAuthenticationOptions.cs
+++ b/src/Dfe.Analytics/FederatedAksAuthenticationOptions.cs
@@ -8,53 +8,29 @@ namespace Dfe.Analytics;
 public class FederatedAksAuthenticationOptions
 {
     /// <summary>
-    /// The project number.
+    /// The workflow identity pool provider audience.
     /// </summary>
     [DisallowNull]
-    public string? ProjectNumber { get; set; }
+    public string? Audience { get; set; }
 
     /// <summary>
-    /// The workflow identity pool name.
+    /// The URL for retrieving an access token for accessing BigQuery.
     /// </summary>
     [DisallowNull]
-    public string? WorkloadIdentityPoolName { get; set; }
+    public string? GenerateAccessTokenUrl { get; set; }
 
-    /// <summary>
-    /// The workflow identity pool provider name.
-    /// </summary>
-    [DisallowNull]
-    public string? WorkloadIdentityPoolProviderName { get; set; }
-
-    /// <summary>
-    /// The service account email.
-    /// </summary>
-    [DisallowNull]
-    public string? ServiceAccountEmail { get; set; }
-
-    [MemberNotNull(nameof(ProjectNumber))]
-    [MemberNotNull(nameof(WorkloadIdentityPoolName))]
-    [MemberNotNull(nameof(WorkloadIdentityPoolProviderName))]
-    [MemberNotNull(nameof(ServiceAccountEmail))]
+    [MemberNotNull(nameof(Audience))]
+    [MemberNotNull(nameof(GenerateAccessTokenUrl))]
     internal void ValidateOptions()
     {
-        if (ProjectNumber is null)
+        if (Audience is null)
         {
-            throw new InvalidOperationException($"{nameof(ProjectNumber)} has not been configured.");
+            throw new InvalidOperationException($"{nameof(Audience)} has not been configured.");
         }
 
-        if (WorkloadIdentityPoolName is null)
+        if (GenerateAccessTokenUrl is null)
         {
-            throw new InvalidOperationException($"{nameof(WorkloadIdentityPoolName)} has not been configured.");
-        }
-
-        if (WorkloadIdentityPoolProviderName is null)
-        {
-            throw new InvalidOperationException($"{nameof(WorkloadIdentityPoolProviderName)} has not been configured.");
-        }
-
-        if (ServiceAccountEmail is null)
-        {
-            throw new InvalidOperationException($"{nameof(ServiceAccountEmail)} has not been configured.");
+            throw new InvalidOperationException($"{nameof(GenerateAccessTokenUrl)} has not been configured.");
         }
     }
 }


### PR DESCRIPTION
This simplifies the options required for `FederatedAksAuthenticationOptions` and adds support for getting them from the  `CredentialsJson` configuration key if it's provided.