### PR TITLE
Handle running job when deploying new configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+Handle job already running when deploying new configuration.
+
 ## 0.4.2
 
 Adds `airbyte_heartbeat` table to streams configuration.

--- a/src/Dfe.Analytics.EFCore/AirbyteApi/AirbyteApiClient.cs
+++ b/src/Dfe.Analytics.EFCore/AirbyteApi/AirbyteApiClient.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -41,7 +42,7 @@ public class AirbyteApiClient(HttpClient httpClient)
         return (await response.Content.ReadFromJsonAsync<GetJobStatusResponse>(_serializerOptions, cancellationToken))!;
     }
 
-    public async Task<TriggerJobResponse> TriggerJobAsync(TriggerJobRequest request, CancellationToken cancellationToken = default)
+    public async Task<TriggerJobResponse?> TryTriggerJobAsync(TriggerJobRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -51,6 +52,13 @@ public class AirbyteApiClient(HttpClient httpClient)
             "api/public/v1/jobs",
             content,
             cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.Conflict &&
+            await response.Content.ReadAsStringAsync(cancellationToken) is string contentString &&
+            contentString.Contains("A sync is already running", StringComparison.Ordinal))
+        {
+            return null;
+        }
 
         await response.EnsureSuccessStatusCodeWithContentAsync();
 

--- a/src/Dfe.Analytics.EFCore/AnalyticsDeployer.cs
+++ b/src/Dfe.Analytics.EFCore/AnalyticsDeployer.cs
@@ -137,13 +137,7 @@ public class AnalyticsDeployer(
         CancellationToken cancellationToken = default)
     {
         var triggerJobResponse = await WithProgressReportingAsync(
-            () => airbyteApiClient.TriggerJobAsync(
-                new TriggerJobRequest
-                {
-                    ConnectionId = connectionId,
-                    JobType = JobType.Sync
-                },
-                cancellationToken),
+            TriggerJobAsync,
             progressReporter,
             "  Creating Airbyte sync job");
 
@@ -153,6 +147,33 @@ public class AnalyticsDeployer(
             WaitForCompletionAsync,
             progressReporter,
             "  Waiting for job to complete");
+
+        async Task<TriggerJobResponse> TriggerJobAsync()
+        {
+            TriggerJobResponse? jobResponse;
+
+            do
+            {
+                jobResponse = await airbyteApiClient.TryTriggerJobAsync(
+                    new TriggerJobRequest
+                    {
+                        ConnectionId = connectionId,
+                        JobType = JobType.Sync
+                    },
+                    cancellationToken);
+
+                if (jobResponse is not null)
+                {
+                    break;
+                }
+
+                // Job is already running; back off and try again
+                await Task.Delay(15000, cancellationToken);
+            }
+            while (jobResponse is null);
+
+            return jobResponse;
+        }
 
         async Task WaitForCompletionAsync()
         {


### PR DESCRIPTION
Triggering a new sync job when one is already running is not allowed; this catches the error thrown when a job is already running then backs off before trying again.