### PR TITLE
Add support for the hidden_DATA field

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ using DfE.Analyics.AspNetCore;
 //...
 httpContext.GetWebRequestEvent()?.AddTag("tag1", "tag2");
 httpContext.GetWebRequestEvent()?.AddData("key", "value1", "value2");
+httpContext.GetWebRequestEvent()?.AddHiddenData("key", "hidden-value1", "hidden-value2");
 ```
 
 

--- a/src/Dfe.Analytics.Core/Events/Event.cs
+++ b/src/Dfe.Analytics.Core/Events/Event.cs
@@ -90,9 +90,14 @@ public class Event
     public string? ResponseStatus { get; set; }
 
     /// <summary>
-    /// Gets the <c>data</c> field.
+    /// Gets the <c>DATA</c> field.
     /// </summary>
     public IDictionary<string, List<string>> Data { get; } = new Dictionary<string, List<string>>();
+
+    /// <summary>
+    /// Gets the <c>hidden_DATA</c> field.
+    /// </summary>
+    public IDictionary<string, List<string>> HiddenData { get; } = new Dictionary<string, List<string>>();
 
     /// <summary>
     /// Gets or sets the <c>entity_table_name</c> field.
@@ -143,6 +148,42 @@ public class Event
         ArgumentNullException.ThrowIfNull(values);
 
         AddData(key, (IEnumerable<string>)values);
+    }
+
+    /// <summary>
+    /// Adds an item to the <see cref="HiddenData"/> bundle with a single value.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> or <paramref name="value"/> is <see langword="null"/>.</exception>
+    public void AddHiddenData(string key, string value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        AddHiddenData(key, [value]);
+    }
+
+    /// <summary>
+    /// Adds an item to the <see cref="HiddenData"/> bundle with multiple values.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> or <paramref name="values"/> is <see langword="null"/>.</exception>
+    public void AddHiddenData(string key, IEnumerable<string> values)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(values);
+
+        HiddenData.Add(key, [.. values]);
+    }
+
+    /// <summary>
+    /// Adds an item to the <see cref="HiddenData"/> bundle with multiple values.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> or <paramref name="values"/> is <see langword="null"/>.</exception>
+    public void AddHiddenData(string key, params string[] values)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(values);
+
+        AddHiddenData(key, (IEnumerable<string>)values);
     }
 
     /// <summary>
@@ -203,8 +244,16 @@ public class Event
             { "response_content_type", ResponseContentType },
             { "response_status", ResponseStatus },
             {
-                "data",
+                "DATA",
                 Data.Select(kvp => new BigQueryInsertRow()
+                {
+                    { "key", kvp.Key },
+                    { "value", kvp.Value }
+                }).ToArray()
+            },
+            {
+                "hidden_DATA",
+                HiddenData.Select(kvp => new BigQueryInsertRow()
                 {
                     { "key", kvp.Key },
                     { "value", kvp.Value }

--- a/tests/Dfe.Analytics.AspNetCore.Tests/IntegrationTests.cs
+++ b/tests/Dfe.Analytics.AspNetCore.Tests/IntegrationTests.cs
@@ -153,7 +153,7 @@ public class IntegrationTests : IClassFixture<IntegrationTestsApplicationFactory
             },
             field =>
             {
-                Assert.Equal("data", field.Key);
+                Assert.Equal("DATA", field.Key);
                 Assert.Collection(
                     Assert.IsAssignableFrom<IEnumerable<BigQueryInsertRow>>(field.Value),
                     row =>
@@ -199,6 +199,42 @@ public class IntegrationTests : IClassFixture<IntegrationTestsApplicationFactory
                             {
                                 Assert.Equal("value", field.Key);
                                 Assert.Collection(Assert.IsAssignableFrom<IEnumerable<string>>(field.Value), v => Assert.Equal("42", v));
+                            });
+                    });
+            },
+            field =>
+            {
+                Assert.Equal("hidden_DATA", field.Key);
+                Assert.Collection(
+                    Assert.IsAssignableFrom<IEnumerable<BigQueryInsertRow>>(field.Value),
+                    row =>
+                    {
+                        Assert.Collection(
+                            row.Cast<KeyValuePair<string, object>>()!,
+                            field =>
+                            {
+                                Assert.Equal("key", field.Key);
+                                Assert.Equal("hidden-data-key1", field.Value);
+                            },
+                            field =>
+                            {
+                                Assert.Equal("value", field.Key);
+                                Assert.Collection(Assert.IsAssignableFrom<IEnumerable<string>>(field.Value), v => Assert.Equal("hidden-data-value1", v));
+                            });
+                    },
+                    row =>
+                    {
+                        Assert.Collection(
+                            row.Cast<KeyValuePair<string, object>>()!,
+                            field =>
+                            {
+                                Assert.Equal("key", field.Key);
+                                Assert.Equal("hidden-data-key2", field.Value);
+                            },
+                            field =>
+                            {
+                                Assert.Equal("value", field.Key);
+                                Assert.Collection(Assert.IsAssignableFrom<IEnumerable<string>>(field.Value), v => Assert.Equal("hidden-data-value2", v));
                             });
                     });
             },
@@ -305,6 +341,8 @@ public class IntegrationTestsStartup
                 var @event = ctx.GetWebRequestEvent();
                 @event?.AddData("data-key1", "data-value1");
                 @event?.AddData("data-key2", "data-value2");
+                @event?.AddHiddenData("hidden-data-key1", "hidden-data-value1");
+                @event?.AddHiddenData("hidden-data-key2", "hidden-data-value2");
                 @event?.AddTags("tag1", "tag2");
 
                 ctx.Response.ContentType = "text/plain";


### PR DESCRIPTION
Sends the `hidden_DATA` field to BQ and adds a set of `AddHiddenData()` methods, mirroring the existing `AddData()` methods.