### PR TITLE
Add option to skip policy tag application

### DIFF
--- a/src/Dfe.Analytics.EFCore/AnalyticsDeployer.cs
+++ b/src/Dfe.Analytics.EFCore/AnalyticsDeployer.cs
@@ -22,6 +22,7 @@ public class AnalyticsDeployer(
         string? airbyteSyncMode,
         string hiddenPolicyTagName,
         IReadOnlyDictionary<string, string> additionalPolicyTags,
+        bool skipPolicyTags,
         IProgressReporter? progressReporter = null,
         CancellationToken cancellationToken = default)
     {
@@ -46,10 +47,13 @@ public class AnalyticsDeployer(
             progressReporter,
             "Waiting for sync to complete");
 
-        await WithProgressReportingAsync(
-            () => UpdateBigQueryPolicyTagsAsync(configuration, hiddenPolicyTagName, additionalPolicyTags, progressReporter, cancellationToken),
-            progressReporter,
-            "Updating BigQuery policy tags");
+        if (!skipPolicyTags)
+        {
+            await WithProgressReportingAsync(
+                () => UpdateBigQueryPolicyTagsAsync(configuration, hiddenPolicyTagName, additionalPolicyTags, progressReporter, cancellationToken),
+                progressReporter,
+                "Updating BigQuery policy tags");
+        }
     }
 
     // internal for testing

--- a/src/Dfe.Analytics.EFCore/Cli/Commands.Config.Apply.cs
+++ b/src/Dfe.Analytics.EFCore/Cli/Commands.Config.Apply.cs
@@ -49,6 +49,7 @@ internal static partial class Commands
                 return policyTagMapping;
             }
         };
+        var skipPolicyTagsOption = new Option<bool>("--skip-policy-tags");
 
         // Airbyte options
         var airbyteApiBaseAddressOption = new Option<string>("--airbyte-api-base-address") { Required = true };
@@ -71,6 +72,7 @@ internal static partial class Commands
             datasetIdOption,
             hiddenPolicyTagNameOption,
             policyTagOption,
+            skipPolicyTagsOption,
             airbyteApiBaseAddressOption,
             airbyteClientIdOption,
             airbyteClientSecretOption,
@@ -91,6 +93,7 @@ internal static partial class Commands
             var datasetId = parseResult.GetRequiredValue(datasetIdOption);
             var hiddenPolicyTagName = parseResult.GetRequiredValue(hiddenPolicyTagNameOption);
             var additionalPolicyTags = parseResult.GetValue(policyTagOption) ?? FrozenDictionary<string, string>.Empty;
+            var skipPolicyTags = parseResult.GetValue(skipPolicyTagsOption);
             var airbyteApiBaseAddress = parseResult.GetRequiredValue(airbyteApiBaseAddressOption);
             var airbyteClientId = parseResult.GetRequiredValue(airbyteClientIdOption);
             var airbyteClientSecret = parseResult.GetRequiredValue(airbyteClientSecretOption);
@@ -133,6 +136,7 @@ internal static partial class Commands
                 airbyteSyncMode,
                 hiddenPolicyTagName,
                 additionalPolicyTags,
+                skipPolicyTags,
                 cancellationToken: cts.Token);
         });
 

--- a/tests/Dfe.Analytics.EFCore.Tests/AnalyticsDeployerTests.cs
+++ b/tests/Dfe.Analytics.EFCore.Tests/AnalyticsDeployerTests.cs
@@ -22,6 +22,120 @@ public class AnalyticsDeployerTests
     private static readonly IReadOnlyDictionary<string, string> NoAdditionalPolicyTags = new Dictionary<string, string>();
 
     [Fact]
+    public async Task DeployAsync_SkipPolicyTagsIsFalse_UpdatesBigQueryPolicyTags()
+    {
+        // Arrange
+        var configuration = GetConfiguration();
+        var connectionId = Guid.NewGuid().ToString();
+        var progressReporter = new RecordingProgressReporter();
+
+        var tableName = configuration.Tables.Select(t => t.Name).Single();
+
+        var httpClientOptions = new HttpClientInterceptorOptions()
+            .ThrowsOnMissingRegistration();
+
+        RegisterAirbyteInterceptions(httpClientOptions, connectionId);
+
+        using var httpClient = httpClientOptions.CreateHttpClient();
+        httpClient.BaseAddress = new Uri("https://dummy-airbyte/");
+
+        var bigQueryClientMock = new Mock<BigQueryClient>();
+
+        bigQueryClientMock
+            .Setup(mock => mock.ListTablesAsync(ProjectId, DatasetId, It.IsAny<ListTablesOptions>()))
+            .Returns(new TestablePagedAsyncEnumerable<TableList, BigQueryTable>([
+                new BigQueryTable(bigQueryClientMock.Object, new Table { TableReference = new TableReference { TableId = tableName } })
+            ]));
+
+        bigQueryClientMock
+            .Setup(mock => mock.GetTableAsync(ProjectId, DatasetId, tableName, It.IsAny<GetTableOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new BigQueryTable(
+                bigQueryClientMock.Object,
+                new Table
+                {
+                    Schema = new TableSchema
+                    {
+                        Fields =
+                        [
+                            new TableFieldSchema { Name = "TestEntityId", Type = "INTEGER" },
+                            new TableFieldSchema { Name = "Name", Type = "STRING" },
+                            new TableFieldSchema { Name = "DateOfBirth", Type = "DATE" }
+                        ]
+                    }
+                }));
+
+        bigQueryClientMock
+            .Setup(mock => mock.PatchTableAsync(
+                ProjectId,
+                DatasetId,
+                tableName,
+                It.Is<Table>(t =>
+                    t.Schema.Fields.Single(f => f.Name == "Name").PolicyTags.Names.Contains(HiddenPolicyTagName)),
+                It.IsAny<PatchTableOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => null)
+            .Verifiable();
+
+        using var dbContext = new NoPendingMigrationsTestDbContext();
+
+        var deployer = CreateDeployer(httpClient, bigQueryClientMock.Object);
+
+        // Act
+        await deployer.DeployAsync(
+            configuration,
+            dbContext,
+            connectionId,
+            airbyteSyncMode: null,
+            HiddenPolicyTagName,
+            NoAdditionalPolicyTags,
+            skipPolicyTags: false,
+            progressReporter,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        bigQueryClientMock.Verify();
+    }
+
+    [Fact]
+    public async Task DeployAsync_SkipPolicyTagsIsTrue_DoesNotUpdateBigQueryPolicyTags()
+    {
+        // Arrange
+        var configuration = GetConfiguration();
+        var connectionId = Guid.NewGuid().ToString();
+        var progressReporter = new RecordingProgressReporter();
+
+        var httpClientOptions = new HttpClientInterceptorOptions()
+            .ThrowsOnMissingRegistration();
+
+        RegisterAirbyteInterceptions(httpClientOptions, connectionId);
+
+        using var httpClient = httpClientOptions.CreateHttpClient();
+        httpClient.BaseAddress = new Uri("https://dummy-airbyte/");
+
+        var bigQueryClientMock = new Mock<BigQueryClient>(MockBehavior.Strict);
+
+        using var dbContext = new NoPendingMigrationsTestDbContext();
+
+        var deployer = CreateDeployer(httpClient, bigQueryClientMock.Object);
+
+        // Act
+        await deployer.DeployAsync(
+            configuration,
+            dbContext,
+            connectionId,
+            airbyteSyncMode: null,
+            HiddenPolicyTagName,
+            NoAdditionalPolicyTags,
+            skipPolicyTags: true,
+            progressReporter,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        bigQueryClientMock.VerifyNoOtherCalls();
+        Assert.DoesNotContain(progressReporter.WrittenLines, l => l.StartsWith("Updating BigQuery policy tags", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ApplyAirbyteConfigurationAsync_UpdatesAirbyteConnectionWithExpectedPayload()
     {
         // Arrange
@@ -579,6 +693,73 @@ public class AnalyticsDeployerTests
         await deployer.CompleteAirbyteSyncAsync(connectionId, progressReporter, TestContext.Current.CancellationToken);
 
         // Assert
+    }
+
+    private static void RegisterAirbyteInterceptions(HttpClientInterceptorOptions httpClientOptions, string connectionId)
+    {
+        var sourceId = Guid.NewGuid().ToString();
+        var jobId = 12345;
+
+        new HttpRequestInterceptionBuilder()
+            .Requests()
+            .ForMethod(new HttpMethod("POST"))
+            .ForHttps()
+            .ForAnyHost()
+            .ForPath("api/v1/connections/get")
+            .Responds()
+            .WithJsonContent(new JsonObject
+            {
+                ["sourceId"] = sourceId
+            })
+            .RegisterWith(httpClientOptions);
+
+        new HttpRequestInterceptionBuilder()
+            .Requests()
+            .ForMethod(new HttpMethod("POST"))
+            .ForHttps()
+            .ForAnyHost()
+            .ForPath("api/v1/sources/discover_schema")
+            .Responds()
+            .WithJsonContent(new JsonObject())
+            .RegisterWith(httpClientOptions);
+
+        new HttpRequestInterceptionBuilder()
+            .Requests()
+            .ForMethod(new HttpMethod("PATCH"))
+            .ForHttps()
+            .ForAnyHost()
+            .ForPath($"api/public/v1/connections/{Uri.EscapeDataString(connectionId)}")
+            .RegisterWith(httpClientOptions);
+
+        new HttpRequestInterceptionBuilder()
+            .Requests()
+            .ForMethod(new HttpMethod("POST"))
+            .ForHttps()
+            .ForAnyHost()
+            .ForPath("api/public/v1/jobs")
+            .Responds()
+            .WithJsonContent(new JsonObject
+            {
+                ["jobId"] = jobId,
+                ["status"] = "running",
+                ["jobType"] = "sync"
+            })
+            .RegisterWith(httpClientOptions);
+
+        new HttpRequestInterceptionBuilder()
+            .Requests()
+            .ForMethod(new HttpMethod("GET"))
+            .ForHttps()
+            .ForAnyHost()
+            .ForPath($"api/public/v1/jobs/{jobId}")
+            .Responds()
+            .WithJsonContent(new JsonObject
+            {
+                ["jobId"] = jobId,
+                ["status"] = "succeeded",
+                ["jobType"] = "sync"
+            })
+            .RegisterWith(httpClientOptions);
     }
 
     private AnalyticsDeployer CreateDeployer(

--- a/tests/Dfe.Analytics.EFCore.Tests/TestDbContext.cs
+++ b/tests/Dfe.Analytics.EFCore.Tests/TestDbContext.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Migrations.Internal;
 
 namespace Dfe.Analytics.EFCore.Tests;
 
@@ -32,4 +34,27 @@ public class TestDbContext : DbContext
         var derivedEntity2Configuration = modelBuilder.Entity<DerivedEntity2>();
         derivedEntity2Configuration.IncludeInAnalyticsSync(includeAllColumns: true, hidden: false);
     }
+}
+
+/// <summary>
+/// A <see cref="TestDbContext"/> that reports no pending migrations without connecting to a database.
+/// </summary>
+public class NoPendingMigrationsTestDbContext : TestDbContext
+{
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        base.OnConfiguring(optionsBuilder);
+
+        optionsBuilder.ReplaceService<IHistoryRepository, EmptyHistoryRepository>();
+    }
+
+#pragma warning disable EF1001  // Internal EF Core API usage
+    private sealed class EmptyHistoryRepository(HistoryRepositoryDependencies dependencies) : NpgsqlHistoryRepository(dependencies)
+    {
+        // Returning false here means no attempt is made to read applied migrations from the database
+        public override bool Exists() => false;
+
+        public override Task<bool> ExistsAsync(CancellationToken cancellationToken = default) => Task.FromResult(false);
+    }
+#pragma warning restore EF1001
 }


### PR DESCRIPTION
The dedup sync mode requires read access to all data, which we don't want to give to non-prod environments (since it also gives access to the prod data). This adds an option to skip applying policy tags. A corresponding change in the terraform modules will populate the new flag.